### PR TITLE
Package name fix and ignore os generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ config.js
 node_modules
 # webstorm
 .idea
+# OS generated
+.DS_Store*
+[Tt]humbs.db

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gitbot",
+  "name": "twgitbot",
   "version": "1.0.0",
   "description": "A simple bot that twits github commits commits",
   "main": "index.js",


### PR DESCRIPTION
I think the package name was changed to twgitbot after the package.js file was created so here is my fix, also for OSX users I added the DS_Store files to the .girignore file.